### PR TITLE
chore: (SDEVOPS-18) Update configurations to build project as library

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "test": "jest",
     "semantic-release": "semantic-release",
     "postinstall": "rm -f node_modules/web3/index.d.ts node_modules/web3/types.d.ts",
-    "build:ts": "ttsc -b --watch .",
+    "build:ts": "ttsc -b .",
     "build:dev": "webpack --mode development --display-error-details",
-    "build:prod": "webpack --mode production"
+    "build:prod": "webpack --mode production && yarn run build:ts"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/package.json
+++ b/package.json
@@ -1,15 +1,18 @@
 {
   "name": "@polymathnetwork/sdk",
-  "version": "0.0.0-development",
+  "version": "0.0.0-alpha.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
+  "files": [
+    "dist/"
+  ],
   "scripts": {
     "test": "jest",
     "semantic-release": "semantic-release",
     "postinstall": "rm -f node_modules/web3/index.d.ts node_modules/web3/types.d.ts",
-    "build:ts": "ttsc -b .",
+    "build:ts": "ttsc -b --watch",
     "build:dev": "webpack --mode development --display-error-details",
-    "build:prod": "webpack --mode production && yarn run build:ts"
+    "build:prod": "webpack --mode production && ttsc -b"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "outDir": "build/dist",
+    "outDir": "dist",
     "rootDir": "src",
     "baseUrl": "src",
     "paths": {
@@ -21,7 +21,7 @@
     "esModuleInterop": true,
     "emitDeclarationOnly": true,
     "jsx": "react",
-    "lib": ["es2017", "dom"],
+    "lib": ["es2017", "dom"]
   },
   "exclude": ["config", "build", "node_modules"]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,12 @@ const { TsconfigPathsPlugin } = require('tsconfig-paths-webpack-plugin');
 
 module.exports = {
   entry: './src/index.ts',
+  output: {
+    filename: 'index.js',
+    library: 'PolymathNetworkSdk',
+    libraryTarget: 'umd',
+    umdNamedDefine: true,
+  },
   resolve: {
     extensions: ['.tsx', '.ts', '.js'],
     plugins: [new TsconfigPathsPlugin()],


### PR DESCRIPTION
Builds project as library targeting UMD and shipping TS type declarations.

- After installing this package in a **test-project**, the installation shows `node_modules/@polymathnetwork/sdk/dist` has desired entry points and type declarations.

- Only the contents of the `dist/` folder are being published.

![image](https://user-images.githubusercontent.com/1607385/55576666-d1db0b80-56df-11e9-91c7-ccde8bf857eb.png)

