### PR TITLE
fix/sdevops-18-sdk-library-build

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@babel/polyfill": "^7.0.0",
     "@babel/runtime": "^7.2.0",
-    "bignumber.js": "^8.0.1",
+    "bignumber.js": "8.0.1",
     "semver": "^5.6.0",
     "uuid": "^3.3.2",
     "web3": "1.0.0-beta.30"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,5 @@
     "jsx": "react",
     "lib": ["es2017", "dom"]
   },
-  "exclude": ["config", "build", "node_modules"]
+  "exclude": ["config", "dist", "node_modules"]
 }


### PR DESCRIPTION
# Summary

47aa1c1 fix: exclude "dist" and not "build" in tsconfig.json
9d819ef fix: fix dependency `"bignumber.js": "8.0.1"`