### PR TITLE
chore: add .npmrc to publish to scoped npm registry

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/package.json
+++ b/package.json
@@ -91,9 +91,16 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/PolymathNetwork/polymath-sdk.git"
+    "url": "git+https://github.com/PolymathNetwork/polymath-sdk.git"
   },
   "release": {
     "branch": "master"
-  }
+  },
+  "description": "A Javascript SDK for interacting with the Polymath network for the browser and Node.js",
+  "bugs": {
+    "url": "https://github.com/PolymathNetwork/polymath-sdk/issues"
+  },
+  "homepage": "https://github.com/PolymathNetwork/polymath-sdk#readme",
+  "author": "",
+  "license": "ISC"
 }


### PR DESCRIPTION
- Adding _.npmrc_ file for publishing
- Cleaning up _package.json_
- Publishing via `npm publish --access public`
  - **semantic-release** won't support `0.0.0-alpha.0` releases