### PR TITLE
chore: the moment of truth... enough dry-runs!

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   ],
   "scripts": {
     "test": "jest",
-    "semantic-release": "semantic-release --no-ci",
     "postinstall": "rm -f node_modules/web3/index.d.ts node_modules/web3/types.d.ts",
     "build:ts": "ttsc -b --watch",
     "build:dev": "webpack --mode development --display-error-details",


### PR DESCRIPTION
# Summary

3affffa chore: the moment of truth... enough dry-runs!
c0f1ad1 docs: add documentation on custom version build step for PRs
1104966 fix: add script to compute version in CI server based on latest tag

- GitHub Pull Request build feature has been configured on TeamCity along with for Status check.
- For example, this pull request:

![image](https://user-images.githubusercontent.com/1607385/56246579-66465600-6070-11e9-8281-af21672fa1d6.png)

![image](https://user-images.githubusercontent.com/1607385/56246692-b0c7d280-6070-11e9-84b0-0bb1ed3c5d81.png)

---

- TeamCity knows that Pull Requests are a special kind of git ref `refs/pull/*/head` and builds them as if they were branches:

![image](https://user-images.githubusercontent.com/1607385/56246746-d8b73600-6070-11e9-8308-35e51ea73447.png)

- The PR build configuration is detects the latest semantic-release version tag on the PR branch, e.g., `v1.0.0` and uses it as prefix of "PR build version number" consisting of:

  ```
  ${Latest-Semantic-Release-Version}-${Git-Commit-Hash-Short}.${Build-Number}
  ```