### PR TITLE
fix: `output.globalObject` in webpack.config.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,6 @@
     "url": "git+https://github.com/PolymathNetwork/polymath-sdk.git"
   },
   "release": {
-    "branch": "master",
     "plugins": [
       "@semantic-release/commit-analyzer",
       "@semantic-release/release-notes-generator",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,6 +7,7 @@ module.exports = {
     library: 'PolymathNetworkSdk',
     libraryTarget: 'umd',
     umdNamedDefine: true,
+    globalObject: this,
   },
   resolve: {
     extensions: ['.tsx', '.ts', '.js'],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,7 @@ module.exports = {
     library: 'PolymathNetworkSdk',
     libraryTarget: 'umd',
     umdNamedDefine: true,
-    globalObject: this,
+    globalObject: 'this',
   },
   resolve: {
     extensions: ['.tsx', '.ts', '.js'],


### PR DESCRIPTION
From Webpack documentation:

> When targeting a library, especially the libraryTarget is 'umd', this option indicates what global object will be used to mount the library. To make UMD build available on both browsers and Node.js, set output.globalObject option to 'this'.

For example:

```
module.exports = {
  // ...
  output: {
    library: 'myLib',
    libraryTarget: 'umd',
    filename: 'myLib.js',
    globalObject: 'this'
  }
};
```

See: https://webpack.js.org/configuration/output/#outputglobalobject