### PR TITLE
Feat/disabled sto

### DIFF
--- a/src/LowLevel/SecurityToken.ts
+++ b/src/LowLevel/SecurityToken.ts
@@ -198,9 +198,8 @@ export class SecurityToken extends Contract<SecurityTokenContract> {
 
   public async getUsdTieredStoModules() {
     const addresses = await this.getUnarchivedModuleAddresses({
-      name: 'UsdTieredSTO',
+      name: 'USDTieredSTO',
     });
-
     const { context } = this;
 
     return addresses.map(address => new UsdTieredSto({ address, context }));

--- a/src/LowLevel/Sto.ts
+++ b/src/LowLevel/Sto.ts
@@ -1,10 +1,14 @@
+import { TransactionObject } from 'web3/eth/types';
 import { Module } from './Module';
 import { Context } from './LowLevel';
 import { GenericContract, StoModuleTypes } from './types';
 
 // This type should be obtained from a library (must match ABI)
 interface StoContract<T extends GenericContract> {
-  methods: {} & T['methods'];
+  methods: {
+    paused(): TransactionObject<boolean>;
+    capReached(): TransactionObject<boolean>;
+  } & T['methods'];
   getPastEvents: T['getPastEvents'];
 }
 
@@ -16,4 +20,12 @@ export abstract class Sto<T extends GenericContract = GenericContract> extends M
   constructor({ address, abi, context }: { address: string; abi: any[]; context: Context }) {
     super({ address, abi, context });
   }
+
+  public paused = async () => {
+    return await this.contract.methods.paused().call();
+  };
+
+  public capReached = async () => {
+    return await this.contract.methods.capReached().call();
+  };
 }

--- a/src/Polymath.ts
+++ b/src/Polymath.ts
@@ -806,6 +806,8 @@ export class Polymath {
           const details = await module.getDetails();
           const investments = await module.getInvestments();
           const { address } = module;
+          const paused = await module.paused();
+          const capReached = await module.capReached();
           const stoModuleId = this.CappedStoModule.generateId({
             securityTokenId,
             stoType,
@@ -822,6 +824,8 @@ export class Polymath {
               investments: investmentEntities,
               stoType,
               address,
+              paused,
+              capReached,
             })
           );
         }
@@ -832,6 +836,8 @@ export class Polymath {
           const { tokensPerTier, ratesPerTier, ...details } = await module.getDetails();
           const investments = await module.getInvestments();
           const { address } = module;
+          const paused = await module.paused();
+          const capReached = await module.capReached();
           const stoModuleId = this.UsdTieredStoModule.generateId({
             securityTokenId,
             stoType,
@@ -851,6 +857,8 @@ export class Polymath {
               investments: investmentEntities,
               stoType,
               address,
+              paused,
+              capReached,
             })
           );
         }

--- a/src/entities/StoModule.ts
+++ b/src/entities/StoModule.ts
@@ -29,6 +29,8 @@ export interface Params extends UniqueIdentifiers {
   soldTokensAmount: BigNumber;
   investorAmount: BigNumber;
   investments: Investment[];
+  paused: boolean;
+  capReached: boolean;
 }
 
 export abstract class StoModule extends Entity {
@@ -56,6 +58,10 @@ export abstract class StoModule extends Entity {
 
   public fundraiseTypes: FundraiseTypes[];
 
+  public paused: boolean;
+
+  public capReached: boolean;
+
   public static unserialize(serialized: string) {
     const unserialized = unserialize(serialized);
 
@@ -81,6 +87,8 @@ export abstract class StoModule extends Entity {
       soldTokensAmount,
       investorAmount,
       investments,
+      paused,
+      capReached,
     } = params;
 
     this.address = address;
@@ -94,6 +102,8 @@ export abstract class StoModule extends Entity {
     this.investorAmount = investorAmount;
     this.investments = investments;
     this.fundraiseTypes = fundraiseTypes;
+    this.paused = paused;
+    this.capReached = capReached;
   }
 
   public toPojo() {


### PR DESCRIPTION
This PR brings two trivial changes:
- Add the ability to tell if an STO is paused or has reached cap.
- Fix a typo that prevented loading USDTieredSTO (we were loading `UsdTieredSTO` instead. Note case of `Usd`).