### PR TITLE
fix: use correct STR getter in `getSecurityTokens`

### DIFF
--- a/src/Polymath.ts
+++ b/src/Polymath.ts
@@ -179,7 +179,7 @@ export class Polymath {
       owner = await currentWallet.address();
     }
 
-    const symbols = await contractWrappers.securityTokenRegistry.getTokensByOwner({ owner });
+    const symbols = await contractWrappers.securityTokenRegistry.getTickersByOwner({ owner });
 
     return P.map(symbols, symbol => {
       return this.getSecurityToken({ symbol });


### PR DESCRIPTION
The problem was caused by using `getTokensByOwner` instead of `getTickersByOwner` (the former
returns a list of addresses)

fix #61