### PR TITLE
feat: expose SecurityTokenReservation data

### DIFF
--- a/src/Polymath.ts
+++ b/src/Polymath.ts
@@ -267,10 +267,21 @@ export class Polymath {
   };
 
   /**
+   * Get the balance of ETH in a wallet
+   *
+   * @param walletAddress wallet to check for balance
+   */
+  public getEthBalance = async (args: { walletAddress: string }) => {
+    const { walletAddress } = args;
+
+    return this.context.contractWrappers.getBalance({ address: walletAddress });
+  };
+
+  /**
    * Get the balance of a specific ERC20 token in a wallet
    *
    * @param tokenAddress address of the ERC20 token
-   * @param wallet wallet to check for balance
+   * @param walletAddress wallet to check for balance
    */
   public getErc20TokenBalance = async (
     args:

--- a/src/entities/SecurityTokenReservation.ts
+++ b/src/entities/SecurityTokenReservation.ts
@@ -17,6 +17,8 @@ function isUniqueIdentifiers(identifiers: any): identifiers is UniqueIdentifiers
 
 export interface Params {
   expiry: Date;
+  reservedAt: Date;
+  ownerAddress: string;
   securityTokenAddress?: string;
 }
 
@@ -50,6 +52,16 @@ export class SecurityTokenReservation extends Entity<Params> {
   public expiry: Date;
 
   /**
+   * Date when the Security Token was reserved
+   */
+  public reservedAt: Date;
+
+  /**
+   * Address of the owner of the reservation
+   */
+  public ownerAddress: string;
+
+  /**
    * Address of the Security Token if it has already been launched, undefined if not
    */
   public securityTokenAddress?: string;
@@ -59,11 +71,13 @@ export class SecurityTokenReservation extends Entity<Params> {
   constructor(params: Params & UniqueIdentifiers, context: Context) {
     super();
 
-    const { symbol, expiry, securityTokenAddress } = params;
+    const { symbol, expiry, reservedAt, securityTokenAddress, ownerAddress } = params;
 
     this.symbol = symbol;
     this.context = context;
     this.expiry = expiry;
+    this.reservedAt = reservedAt;
+    this.ownerAddress = ownerAddress;
     this.securityTokenAddress = securityTokenAddress;
     this.uid = SecurityTokenReservation.generateId({ symbol });
   }

--- a/src/entities/factories/SecurityTokenReservationFactory.ts
+++ b/src/entities/factories/SecurityTokenReservationFactory.ts
@@ -16,7 +16,12 @@ export class SecurityTokenReservationFactory extends Factory<
       contractWrappers: { securityTokenRegistry, tokenFactory },
     } = this.context;
 
-    const { status, expiryDate } = await securityTokenRegistry.getTickerDetails({ ticker: symbol });
+    const {
+      status,
+      expiryDate,
+      owner,
+      registrationDate,
+    } = await securityTokenRegistry.getTickerDetails({ ticker: symbol });
 
     if (!status) {
       throw new PolymathError({
@@ -33,7 +38,12 @@ export class SecurityTokenReservationFactory extends Factory<
       // we reach this point if the token hasn't been launched, so we just ignore it
     }
 
-    return { expiry: expiryDate, securityTokenAddress };
+    return {
+      expiry: expiryDate,
+      reservedAt: registrationDate,
+      ownerAddress: owner,
+      securityTokenAddress,
+    };
   };
 
   constructor(context: Context) {

--- a/src/procedures/ReserveSecurityToken.ts
+++ b/src/procedures/ReserveSecurityToken.ts
@@ -76,12 +76,14 @@ export class ReserveSecurityToken extends Procedure<
         if (event) {
           const { args: eventArgs } = event;
 
-          const { _ticker, _expiryDate } = eventArgs;
+          const { _ticker, _expiryDate, _owner, _registrationDate } = eventArgs;
 
           return securityTokenReservationFactory.create(
             SecurityTokenReservation.generateId({ symbol: _ticker }),
             {
               expiry: bigNumberToDate(_expiryDate),
+              reservedAt: bigNumberToDate(_registrationDate),
+              ownerAddress: _owner,
             }
           );
         }


### PR DESCRIPTION
`ownerAddress` (string) and `reservedAt` (Date) can be accessed now. Also added a `getEthBalance`
function to the SDK client