### PR TITLE
fix: pass options to module address getter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ yarn-error.log
 npm-package/
 .idea/
 coverage/
+test.ts

--- a/src/PolymathBase.ts
+++ b/src/PolymathBase.ts
@@ -275,7 +275,7 @@ export class PolymathBase extends PolymathAPI {
   ): Promise<any[]> => {
     const { moduleFactory } = this;
 
-    const moduleAddresses = await this.getModuleAddressesByName({ moduleName, symbol });
+    const moduleAddresses = await this.getModuleAddressesByName({ moduleName, symbol }, opts);
 
     const { getModuleInstance } = moduleFactory;
 


### PR DESCRIPTION
This fixes a bug that caused archived modules to be fetched even when `unarchived` was passed as
true

close #108