### PR TITLE
fix(permissions): retrieve delegate details

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@0x/subproviders": "^3.0.2",
     "@babel/polyfill": "^7.0.0",
     "@babel/runtime": "^7.2.0",
-    "@polymathnetwork/contract-wrappers": "3.0.0-beta.54",
+    "@polymathnetwork/contract-wrappers": "3.0.0-beta.56",
     "@types/sinon": "^7.5.0",
     "bluebird": "^3.5.5",
     "ethereum-address": "^0.0.4",

--- a/src/entities/SecurityToken/Permissions.ts
+++ b/src/entities/SecurityToken/Permissions.ts
@@ -186,7 +186,7 @@ export class Permissions extends SubModule {
   };
 
   /**
-   * Returns the list of delegate addresses that hold a specific role
+   * Returns the list of delegate addresses and details that hold a specific role
    *
    * @param role role for which delegates must be fetched
    */
@@ -217,14 +217,23 @@ export class Permissions extends SubModule {
       { unarchived: true }
     ))[0];
 
-    return generalPermissionManager.getAllDelegatesWithPerm({
+    const delegatesWithPerm = await generalPermissionManager.getAllDelegatesWithPerm({
       module: moduleAddress,
       perm: permission,
+    });
+
+    return P.map(delegatesWithPerm, async delegateAddress => {
+      const details = await generalPermissionManager.delegateDetails({ delegate: delegateAddress });
+
+      return {
+        delegateAddress,
+        details,
+      };
     });
   };
 
   /**
-   * Returns a list of all delegates with their respective roles
+   * Returns a list of all delegates with their respective details and roles
    */
   public getAllDelegates = async () => {
     const {
@@ -249,10 +258,12 @@ export class Permissions extends SubModule {
 
     return P.map(delegates, async delegateAddress => {
       const roles = await this.getAssignedRoles({ delegateAddress });
+      const details = await generalPermissionManager.delegateDetails({ delegate: delegateAddress });
 
       return {
         delegateAddress,
         roles,
+        details,
       };
     });
   };

--- a/src/entities/SecurityToken/Permissions.ts
+++ b/src/entities/SecurityToken/Permissions.ts
@@ -223,11 +223,13 @@ export class Permissions extends SubModule {
     });
 
     return P.map(delegatesWithPerm, async delegateAddress => {
-      const details = await generalPermissionManager.delegateDetails({ delegate: delegateAddress });
+      const description = await generalPermissionManager.delegateDetails({
+        delegate: delegateAddress,
+      });
 
       return {
-        delegateAddress,
-        details,
+        address: delegateAddress,
+        description,
       };
     });
   };
@@ -257,13 +259,17 @@ export class Permissions extends SubModule {
     const delegates = await generalPermissionManager.getAllDelegates();
 
     return P.map(delegates, async delegateAddress => {
-      const roles = await this.getAssignedRoles({ delegateAddress });
-      const details = await generalPermissionManager.delegateDetails({ delegate: delegateAddress });
+      const [roles, description] = await Promise.all([
+        this.getAssignedRoles({ delegateAddress }),
+        generalPermissionManager.delegateDetails({
+          delegate: delegateAddress,
+        }),
+      ]);
 
       return {
-        delegateAddress,
+        address: delegateAddress,
         roles,
-        details,
+        description,
       };
     });
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1335,10 +1335,10 @@
     lodash "^4.17.15"
     typescript "3.5.3"
 
-"@polymathnetwork/contract-wrappers@3.0.0-beta.54":
-  version "3.0.0-beta.54"
-  resolved "https://registry.yarnpkg.com/@polymathnetwork/contract-wrappers/-/contract-wrappers-3.0.0-beta.54.tgz#07508de716bcaa78b7c9ffc4c5b12fee9622ecef"
-  integrity sha512-nSc7PIjg+aGFSacvSGnCmZfR5u2OHmgL1kH2nIi3ySvdlF9KoBWb5yz0QAZIUyTOZPfW72reKyVcEco6lA7ZOA==
+"@polymathnetwork/contract-wrappers@3.0.0-beta.56":
+  version "3.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@polymathnetwork/contract-wrappers/-/contract-wrappers-3.0.0-beta.56.tgz#bc76dbb9939f90beb75da4969c3046af9c0d922f"
+  integrity sha512-LX/o2Gp7ZR77XOZtfeR8t5QFZ6syXeXNQgKWzuwAxC0tJCLlb7c93xU3sxq0UWgHgMfnChI29ZIq1mGVkf8Q2Q==
   dependencies:
     "@0x/assert" "2.1.6"
     "@0x/json-schemas" "4.0.2"


### PR DESCRIPTION
Delegate details are retrieved whenever user get delegates

BREAKING CHANGE: getDelegatesForRole and getAllDelegates now returns an extra property

fix #102