### PR TITLE
Fix/refine tiered sto types

### DIFF
--- a/src/entities/SecurityToken/Issuance/Offerings.ts
+++ b/src/entities/SecurityToken/Issuance/Offerings.ts
@@ -24,22 +24,19 @@ interface LaunchTieredStoParams {
   currencies: Currency[];
   raisedFundsWallet: string;
   unsoldTokensWallet: string;
-  stableCoinAddresses: string[];
+  stableCoinAddresses?: string[];
   customCurrency?: Partial<CustomCurrency>;
   allowPreIssuance?: boolean;
 }
 
-type OnlyEth =
-  | [Currency.ETH]
-  | [Currency.StableCoin, Currency.ETH]
-  | [Currency.ETH, Currency.StableCoin];
-type OnlyPoly =
-  | [Currency.POLY]
+type OnlyEth = [Currency.ETH];
+type EthAndStableCoin = [Currency.StableCoin, Currency.ETH] | [Currency.ETH, Currency.StableCoin];
+type OnlyPoly = [Currency.POLY];
+type PolyAndStableCoin =
   | [Currency.StableCoin, Currency.POLY]
   | [Currency.POLY, Currency.StableCoin];
-type EthAndPoly =
-  | [Currency.ETH, Currency.POLY]
-  | [Currency.POLY, Currency.ETH]
+type EthAndPoly = [Currency.ETH, Currency.POLY] | [Currency.POLY, Currency.ETH];
+type AllCurrencies =
   | [Currency.StableCoin, Currency.ETH, Currency.POLY]
   | [Currency.ETH, Currency.StableCoin, Currency.POLY]
   | [Currency.ETH, Currency.POLY, Currency.StableCoin]
@@ -47,12 +44,28 @@ type EthAndPoly =
   | [Currency.POLY, Currency.StableCoin, Currency.ETH]
   | [Currency.POLY, Currency.ETH, Currency.StableCoin];
 
-interface LaunchTieredStoNoCustomCurrencyParams
-  extends Omit<LaunchTieredStoParams, 'customCurrency'> {
+interface LaunchTieredStoNoCustomCurrencyNoStableCoinParams
+  extends Omit<Omit<LaunchTieredStoParams, 'customCurrency'>, 'stableCoinAddresses'> {
   currencies: OnlyEth | OnlyPoly | EthAndPoly;
 }
 
+interface LaunchTieredStoNoCustomCurrencyParams
+  extends Omit<LaunchTieredStoParams, 'customCurrency'> {
+  currencies: EthAndStableCoin | PolyAndStableCoin | AllCurrencies;
+  stableCoinAddresses: string[];
+}
+
 interface LaunchTieredStoCustomCurrencyEthParams extends LaunchTieredStoParams {
+  currencies: OnlyEth | EthAndStableCoin;
+  customCurrency: {
+    currencySymbol?: string;
+    ethOracleAddress: string;
+  };
+  stableCoinAddresses: string[];
+}
+
+interface LaunchTieredStoCustomCurrencyEthNoStableCoinParams
+  extends Omit<LaunchTieredStoParams, 'stableCoinAddresses'> {
   currencies: OnlyEth;
   customCurrency: {
     currencySymbol?: string;
@@ -61,6 +74,16 @@ interface LaunchTieredStoCustomCurrencyEthParams extends LaunchTieredStoParams {
 }
 
 interface LaunchTieredStoCustomCurrencyPolyParams extends LaunchTieredStoParams {
+  currencies: OnlyPoly | PolyAndStableCoin;
+  customCurrency: {
+    currencySymbol?: string;
+    polyOracleAddress: string;
+  };
+  stableCoinAddresses: string[];
+}
+
+interface LaunchTieredStoCustomCurrencyPolyNoStableCoinParams
+  extends Omit<LaunchTieredStoParams, 'stableCoinAddresses'> {
   currencies: OnlyPoly;
   customCurrency: {
     currencySymbol?: string;
@@ -69,6 +92,17 @@ interface LaunchTieredStoCustomCurrencyPolyParams extends LaunchTieredStoParams 
 }
 
 interface LaunchTieredStoCustomCurrencyBothParams extends LaunchTieredStoParams {
+  currencies: AllCurrencies;
+  customCurrency: {
+    currencySymbol?: string;
+    ethOracleAddress: string;
+    polyOracleAddress: string;
+  };
+  stableCoinAddresses: string[];
+}
+
+interface LaunchTieredStoCustomCurrencyBothNoStableCoinParams
+  extends Omit<LaunchTieredStoParams, 'stableCoinAddresses'> {
   currencies: EthAndPoly;
   customCurrency: {
     currencySymbol?: string;
@@ -79,16 +113,28 @@ interface LaunchTieredStoCustomCurrencyBothParams extends LaunchTieredStoParams 
 
 interface LaunchTieredStoMethod {
   (args: LaunchTieredStoNoCustomCurrencyParams): Promise<
-    TransactionQueue<LaunchTieredStoProcedureArgs>
+    TransactionQueue<LaunchTieredStoProcedureArgs, TieredSto>
+  >;
+  (args: LaunchTieredStoNoCustomCurrencyNoStableCoinParams): Promise<
+    TransactionQueue<LaunchTieredStoProcedureArgs, TieredSto>
   >;
   (args: LaunchTieredStoCustomCurrencyEthParams): Promise<
-    TransactionQueue<LaunchTieredStoProcedureArgs>
+    TransactionQueue<LaunchTieredStoProcedureArgs, TieredSto>
+  >;
+  (args: LaunchTieredStoCustomCurrencyEthNoStableCoinParams): Promise<
+    TransactionQueue<LaunchTieredStoProcedureArgs, TieredSto>
   >;
   (args: LaunchTieredStoCustomCurrencyPolyParams): Promise<
-    TransactionQueue<LaunchTieredStoProcedureArgs>
+    TransactionQueue<LaunchTieredStoProcedureArgs, TieredSto>
+  >;
+  (args: LaunchTieredStoCustomCurrencyPolyNoStableCoinParams): Promise<
+    TransactionQueue<LaunchTieredStoProcedureArgs, TieredSto>
   >;
   (args: LaunchTieredStoCustomCurrencyBothParams): Promise<
-    TransactionQueue<LaunchTieredStoProcedureArgs>
+    TransactionQueue<LaunchTieredStoProcedureArgs, TieredSto>
+  >;
+  (args: LaunchTieredStoCustomCurrencyBothNoStableCoinParams): Promise<
+    TransactionQueue<LaunchTieredStoProcedureArgs, TieredSto>
   >;
 }
 

--- a/src/procedures/LaunchSimpleSto.ts
+++ b/src/procedures/LaunchSimpleSto.ts
@@ -74,10 +74,16 @@ export class LaunchSimpleSto extends Procedure<LaunchSimpleStoProcedureArgs, Sim
       usdCost = cost;
     }
 
-    await this.addProcedure(TransferErc20)({
-      receiver: securityTokenAddress,
-      amount: polyCost,
-    });
+    const balance = await contractWrappers.polyToken.balanceOf({ owner: securityTokenAddress });
+    const difference = polyCost.minus(balance);
+
+    // only transfer the required amount of POLY
+    if (difference.gt(new BigNumber(0))) {
+      await this.addProcedure(TransferErc20)({
+        receiver: securityTokenAddress,
+        amount: difference,
+      });
+    }
 
     const fundRaiseType =
       currency === Currency.ETH ? CappedSTOFundRaiseType.ETH : CappedSTOFundRaiseType.POLY;

--- a/src/procedures/LaunchTieredSto.ts
+++ b/src/procedures/LaunchTieredSto.ts
@@ -35,7 +35,7 @@ export class LaunchTieredSto extends Procedure<LaunchTieredStoProcedureArgs, Tie
       currencies,
       raisedFundsWallet,
       unsoldTokensWallet,
-      stableCoinAddresses,
+      stableCoinAddresses = [],
       customCurrency,
       allowPreIssuing = false,
     } = args;
@@ -54,6 +54,13 @@ export class LaunchTieredSto extends Procedure<LaunchTieredStoProcedureArgs, Tie
       throw new PolymathError({
         code: ErrorCode.ProcedureValidationError,
         message: `There is no Security Token with symbol ${symbol}`,
+      });
+    }
+
+    if (currencies.includes(FundRaiseType.StableCoin) && stableCoinAddresses.length === 0) {
+      throw new PolymathError({
+        code: ErrorCode.ProcedureValidationError,
+        message: 'Stable Coin address array cannot be empty if raising in Stable Coin',
       });
     }
 
@@ -139,6 +146,29 @@ export class LaunchTieredSto extends Procedure<LaunchTieredStoProcedureArgs, Tie
         tokensPerTierDiscountPoly.push(tokensWithDiscount);
       }
     );
+
+    console.log('DATA', {
+      moduleName,
+      address: factoryAddress,
+      data: {
+        startTime: startDate,
+        endTime: endDate,
+        ratePerTier,
+        ratePerTierDiscountPoly,
+        tokensPerTierTotal,
+        tokensPerTierDiscountPoly,
+        nonAccreditedLimitUSD: nonAccreditedInvestmentLimit,
+        minimumInvestmentUSD: minimumInvestment,
+        fundRaiseTypes: currencies,
+        wallet: raisedFundsWallet,
+        treasuryWallet: unsoldTokensWallet,
+        stableTokens: stableCoinAddresses,
+        customOracleAddresses,
+        denominatedCurrency,
+      },
+      maxCost: polyCost,
+      archived: false,
+    });
 
     const [newStoAddress, newSto] = await this.addTransaction<
       TransactionParams.SecurityToken.AddUSDTieredSTO,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -392,7 +392,7 @@ export interface LaunchTieredStoProcedureArgs {
   currencies: Currency[];
   raisedFundsWallet: string;
   unsoldTokensWallet: string;
-  stableCoinAddresses: string[];
+  stableCoinAddresses?: string[];
   customCurrency?: Partial<CustomCurrency>;
   allowPreIssuing?: boolean;
 }
@@ -743,7 +743,7 @@ export enum TransferStatusCode {
  * @param T - type to exclude from
  * @param K - name of the property that will be excluded
  */
-export type Omit<T, K> = { [key in Exclude<keyof T, K>]: T[key] };
+export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
 /**
  * Transaction method from the contract-wrappers package


### PR DESCRIPTION
This PR:

- Refines Launch Tiered STO types to manage edge cases with currencies/stable coin addresses. For example, if StableCoin is one of the supported currencies, then the stable coin address array must be supplied, and an error will be thrown if it is empty. At the same time, if StableCoin is NOT one of the supported currencies, the stable coin address array cannot be supplied
- Makes it so that only the amount of POLY required to launch the STO is transferred to the Security Token. If the ST already owns an amount of POLY, only the amount left to cover the cost is transferred